### PR TITLE
fix: formatted amounts with donation currency

### DIFF
--- a/web/components/dashboard/views/CreateCampaignView.tsx
+++ b/web/components/dashboard/views/CreateCampaignView.tsx
@@ -103,7 +103,7 @@ export const CreateCampaignView: FC<CreateCampaignViewProps> = ({
         />
         <input
           type="number"
-          placeholder="amount in sols"
+          placeholder="Amount (◎)"
           className="bg-white p-3 w-[22rem] rounded-xl focus-visible::border-0"
         />
         <input

--- a/web/components/dashboard/views/DetailsView.tsx
+++ b/web/components/dashboard/views/DetailsView.tsx
@@ -31,8 +31,8 @@ export const DetailsView: FC<DetailsViewProps> = ({
         <p className="text-xl font-bold">{category}</p>
         <p className="my-20 text-3xl font-extrabold">{title}</p>
         <div className="border-2 rounded-lg border-black w-full h-[6rem] my-3 flex">
-          <InnerAmt text={'Raised'} amount={raised} />
-          <InnerAmt text={'Target'} amount={amount} />
+          <InnerAmt text={'Raised (◎)'} amount={raised} />
+          <InnerAmt text={'Target (◎)'} amount={amount} />
           <InnerAmt text={'Days left'} amount={daysLeft} />
         </div>
         <div className="mt-auto">

--- a/web/components/dashboard/views/DonateView.tsx
+++ b/web/components/dashboard/views/DonateView.tsx
@@ -11,7 +11,7 @@ export const DonateView: FC<DonateViewProps> = ({ onClick }) => {
         <div className="flex flex-col gap-4 mb-4">
           <input
             type="number"
-            placeholder="Enter donation amount"
+            placeholder="Enter donation amount (◎)"
             className="bg-white p-3 px-12 rounded-xl focus-visible::border-0"
           />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Formatted the amounts to include the donation currency (SOL - ◎) so users are not mistaken

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It ensures that users are always aware of what currency the input/display field is for/rendering to avoid unintended financial losses

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested on a local development server

## Screenshots (if appropriate):
![Screenshot_1](https://github.com/user-attachments/assets/ff8dea80-bf19-4a5a-a770-d531322406ba)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.